### PR TITLE
docs: add CONTRIBUTING.md guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to 12th Physics
+
+Thank you for your interest in contributing to **12th Physics**! We welcome contributions from the community to help improve and expand educational resources.
+
+## How to Contribute
+
+1. **Fork the Repository**: Click the "Fork" button at the top right of this repository to create your own copy.
+2. **Clone your Fork**:
+   ```bash
+   git clone https://github.com/<your-username>/12th-physics.git
+   cd 12th-physics
+   ```
+3. **Create a Feature Branch**:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+4. **Make your Changes**: Ensure your additions or fixes are clear, accurate, and follow the project layout.
+5. **Commit your Changes**: Use meaningful commit messages:
+   ```bash
+   git commit -m "docs: describe your changes"
+   ```
+6. **Push to your Fork**:
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+7. **Open a Pull Request**: Go to the original repository on GitHub and click "New Pull Request" comparing your feature branch against the `develop` branch.
+
+## Code & Content Style Guidelines
+
+- Keep formatting clean and consistent.
+- Ensure accuracy in all educational contents, textbook materials, or scripts provided.
+- Avoid committing unnecessary binary or temporary files.
+
+## Reporting Issues
+
+If you find a bug or have a suggestion, please open an issue in the main repository with a clear description and steps to reproduce.
+
+Thank you for contributing!


### PR DESCRIPTION
This PR adds a comprehensive `CONTRIBUTING.md` guideline file to assist contributors in setting up, creating feature branches, adhering to style guidelines, and submitting contributions to the project.